### PR TITLE
商品編集ページ遷移修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,7 +52,7 @@ class ItemsController < ApplicationController
 
   def move_to_index
     
-    if !current_user.id == !@item.user_id || @item.order.present?
+    if current_user.id != @item.user_id || @item.order.present?
       redirect_to action: :index
     end
   end


### PR DESCRIPTION
# What
ログインしたユーザーと商品のユーザーが同じ場合、編集ページに行けるよう修正
# Way
商品購入機能実装のため

（１度LGTMを頂きましたが、ローカルで確認したところ、以前のコードだと、ログインしたユーザーと商品のユーザーが同じ場合に編集ページに行けず、トップページに遷移してしまう仕様だったため、再度プルリクエストしました。
お手数ですが、今一度LGTMを頂けたら幸いです）